### PR TITLE
correction of lost length when callback is called

### DIFF
--- a/src/vfs/vfs-file-monitor.c
+++ b/src/vfs/vfs-file-monitor.c
@@ -404,15 +404,17 @@ static void dispatch_event( VFSFileMonitor * monitor,
 {
     VFSFileMonitorCallbackEntry * cb;
     VFSFileMonitorCallback func;
-    int i;
+    int i, savelen;
     /* Call the callback functions */
     if ( monitor->callbacks && monitor->callbacks->len )
-    {
+      {
+        savelen=monitor->callbacks->len;
         cb = ( VFSFileMonitorCallbackEntry* ) monitor->callbacks->data;
-        for ( i = 0; i < monitor->callbacks->len; ++i )
-        {
+        for ( i = 0; i < savelen; ++i )
+          {
             func = cb[ i ].callback;
-            func( monitor, evt, file_name, cb[ i ].user_data );
+            if (func!=NULL)
+              func( monitor, evt, file_name, cb[ i ].user_data );
         }
     }
 }


### PR DESCRIPTION
Using debian package with debian patches and with udevil mount program when I 

1. launch spacefm
2. plug an USB flash drive (with udevil it is automatically mounted)
3. umount the USB flash drive using icon for displaying peripherals/device and right click on icon of the USB device
4. segfault occur

The callback is launched it erase the directory (normal behavior) and monitor, thus  `monitor->callbacks->len` is lost, leading to inconsistent loop (for me it continue the loop with inconsistent file_path leading to segfault).

Thanks for keeping spacefm alive